### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A comprehensive **Model Context Protocol (MCP) server** that provides seamless integration with [Float.com](https://float.com) - the resource management and project planning platform. This server exposes Float's complete API as MCP tools, enabling AI assistants like Claude to interact with Float for project management, resource allocation, time tracking, and team coordination.
 
+<a href="https://glama.ai/mcp/servers/@asachs01/float-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@asachs01/float-mcp/badge" alt="float-mcp MCP server" />
+</a>
+
 ## 🌟 Features
 
 ### **Complete Float API Coverage**


### PR DESCRIPTION
This PR adds a badge for the [float-mcp](https://glama.ai/mcp/servers/@asachs01/float-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@asachs01/float-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@asachs01/float-mcp/badge" alt="float-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.