### PR TITLE
fix: use 'notes' (plural) instead of 'note' for Float API logged time entries

### DIFF
--- a/src/tools/optimized/manage-time-tracking.ts
+++ b/src/tools/optimized/manage-time-tracking.ts
@@ -104,7 +104,10 @@ const timeTrackingCreateUpdateDataSchema = z
   .object({
     // Logged time fields
     hours: z.number().optional().describe('Hours logged or time off hours'),
-    note: z.string().optional().describe('Note or description'),
+    notes: z
+      .string()
+      .optional()
+      .describe('Notes or description for logged time entries or holidays'),
     reference_date: z.string().optional().describe('Reference date for UI suggestions'),
 
     // Time off fields
@@ -128,7 +131,6 @@ const timeTrackingCreateUpdateDataSchema = z
     type: z.string().optional().describe('Holiday type'),
     moveable: z.number().optional().describe('Moveable flag (0=fixed, 1=moveable)'),
     year: z.number().optional().describe('Year for the holiday'),
-    notes: z.string().optional().describe('Additional notes'),
     holiday_type: z.number().optional().describe('Holiday type (0=full day, 1=partial day)'),
     recurrence_pattern: z.string().optional().describe('Recurrence pattern'),
     created_by: z.number().optional().describe('User ID who created'),
@@ -145,7 +147,7 @@ const timeTrackingCreateUpdateDataSchema = z
           date: z.string(),
           hours: z.number(),
           billable: z.union([z.string(), z.number()]).optional(),
-          note: z.string().optional(),
+          notes: z.string().optional(),
           reference_date: z.string().optional(),
         })
       )

--- a/src/tools/time-management/logged-time.ts
+++ b/src/tools/time-management/logged-time.ts
@@ -61,7 +61,7 @@ export const createLoggedTime = createTool(
       .union([z.string(), z.number()])
       .optional()
       .describe('Whether the time is billable (1 = billable, 0 = non-billable)'),
-    note: z.string().optional().describe('Optional note describing the work done'),
+    notes: z.string().optional().describe('Optional notes describing the work done'),
     reference_date: z.string().optional().describe('Reference date for UI suggestions'),
   }),
   async (params) => {
@@ -91,7 +91,7 @@ export const updateLoggedTime = createTool(
       .union([z.string(), z.number()])
       .optional()
       .describe('Whether the time is billable (1 = billable, 0 = non-billable)'),
-    note: z.string().optional().describe('Optional note describing the work done'),
+    notes: z.string().optional().describe('Optional notes describing the work done'),
     reference_date: z.string().optional().describe('Reference date for UI suggestions'),
   }),
   async (params) => {
@@ -139,7 +139,7 @@ export const bulkCreateLoggedTime = createTool(
             .union([z.string(), z.number()])
             .optional()
             .describe('Whether the time is billable (1 = billable, 0 = non-billable)'),
-          note: z.string().optional().describe('Optional note describing the work done'),
+          notes: z.string().optional().describe('Optional notes describing the work done'),
           reference_date: z.string().optional().describe('Reference date for UI suggestions'),
         })
       )

--- a/src/types/float.ts
+++ b/src/types/float.ts
@@ -319,7 +319,7 @@ export const loggedTimeSchema = z.object({
   date: z.string().nullable().optional(), // Date the time was logged (YYYY-MM-DD)
   hours: z.number().nullable().optional(), // Hours logged
   billable: z.number().nullable().optional(), // 1 = billable, 0 = non-billable
-  note: z.string().nullable().optional(), // Optional note describing the work
+  notes: z.string().nullable().optional(), // Optional notes describing the work
   reference_date: z.string().nullable().optional(), // Reference date for UI suggestions
   locked: z.number().nullable().optional(), // 1 = locked, 0 = unlocked
   created: z.string().nullable().optional(), // Float API uses 'created', not 'created_at'

--- a/tests/integration/tools/optimized/manage-time-tracking.integration.test.ts
+++ b/tests/integration/tools/optimized/manage-time-tracking.integration.test.ts
@@ -176,7 +176,7 @@ describe('Manage Time Tracking Tool Integration Tests', () => {
             task_id: 1,
             hours: 4,
             date: '2024-01-01',
-            note: 'Morning work',
+            notes: 'Morning work',
           },
           {
             people_id: 1,
@@ -184,7 +184,7 @@ describe('Manage Time Tracking Tool Integration Tests', () => {
             task_id: 1,
             hours: 4,
             date: '2024-01-02',
-            note: 'Afternoon work',
+            notes: 'Afternoon work',
           },
         ];
 


### PR DESCRIPTION
## Summary
- Fixes the "Notes" field not persisting issue by changing `note` (singular) to `notes` (plural) in API requests
- The Float API expects `notes` for logged time entries, but the code was sending `note`

## Changes Made
1. **`src/tools/time-management/logged-time.ts`**: Fixed all 3 instances (lines 64, 94, 142)
2. **`src/tools/optimized/manage-time-tracking.ts`**: Fixed schema definitions for logged time
3. **`src/types/float.ts`**: Fixed `loggedTimeSchema` field name from `note` to `notes`
4. **Tests**: Updated integration test to use correct field name

## Test Plan
- [x] TypeScript type checking passes
- [x] ESLint and Prettier checks pass
- [x] All 387 tests pass
- [ ] Manual verification: Create a logged time entry with notes and verify it persists

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `note` with `notes` for logged time across tools, schemas, and tests to match the Float API.
> 
> - **Tools**:
>   - `src/tools/time-management/logged-time.ts`: Switch request schemas to `notes` in create, update, and bulk-create.
>   - `src/tools/optimized/manage-time-tracking.ts`: Align create/update data and `logged_time_entries` to use `notes`; adjust descriptions accordingly.
> - **Types**:
>   - `src/types/float.ts`: Update `loggedTimeSchema` field from `note` to `notes`.
> - **Tests**:
>   - `tests/integration/tools/optimized/manage-time-tracking.integration.test.ts`: Use `notes` in bulk create logged time entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ea6a14525b56468174c6ec9500f3e93be492a73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->